### PR TITLE
Fixed some GitHub-related typos in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ You may want to clean up your uploads folder over time if you re-run a put step 
    during an `in` and pushing a release to a repo during an `out`. The access
    token you create is only required to have the `repo` or `public_repo` scope.
 
-* `gitlab_api_url`: *Optional.* If you use a non-public GitHub deployment then
+* `gitlab_api_url`: *Optional.* If you use a non-public GitLab deployment then
   you can set your API URL here.
 
 * `insecure`: *Optional. Default `false`.* When set to `true`, concourse will allow
-  insecure connection to your github API.
+  insecure connection to your gitlab API.
 
 * `tag_filter`: *Optional.* If set, override default tag filter regular
   expression of `v?([^v].*)`. If the filter includes a capture group, the capture
@@ -51,15 +51,15 @@ You may want to clean up your uploads folder over time if you re-run a put step 
 To get a specific version of a release:
 
 ``` yaml
-- get: gh-release
+- get: gl-release
   version: { tag: 'v0.0.1' }
 ```
 
 To set a custom tag filter:
 
 ```yaml
-- name: gh-release
-  type: github-release
+- name: gl-release
+  type: gitlab-release
   source:
     owner: concourse
     repository: concourse
@@ -132,7 +132,7 @@ will stop the build.
 Run the tests with the following command:
 
 ```sh
-docker build -t github-release-resource .
+docker build -t gitlab-release-resource .
 ```
 
 ### Contributing

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ matching the patterns in `globs` to the release.
 
 #### Parameters
 
-* `commitish`: *Required.* A path to a file containing the commitish (SHA, tag,
+* `commitish`: *Optional, if tag is not specified.* A path to a file containing the commitish (SHA, tag,
   branch name) that the new tag and release should be associated with.
 
 * `tag`: *Required.* A path to a file containing the name of the Git tag to use

--- a/out_command.go
+++ b/out_command.go
@@ -36,11 +36,6 @@ func (c *OutCommand) Run(sourceDir string, request OutRequest) (OutResponse, err
 
 	tag_name = request.Params.TagPrefix + tag_name
 
-	targetCommitish, err := c.fileContents(filepath.Join(sourceDir, request.Params.CommitishPath))
-	if err != nil {
-		return OutResponse{}, err
-	}
-
 	// if request.Params.BodyPath != "" {
 	// 	_, err := c.fileContents(filepath.Join(sourceDir, request.Params.BodyPath))
 	// 	if err != nil {
@@ -57,6 +52,10 @@ func (c *OutCommand) Run(sourceDir string, request OutRequest) (OutResponse, err
 
 	// create the tag first, as next sections assume the tag exists
 	if !tagExists {
+		targetCommitish, err := c.fileContents(filepath.Join(sourceDir, request.Params.CommitishPath))
+		if err != nil {
+			return OutResponse{}, err
+		}
 		tag, err = c.gitlab.CreateTag(targetCommitish, tag_name)
 		if err != nil {
 			return OutResponse{}, err


### PR DESCRIPTION
Hiya,

This is just a quick one. There were a few typos in the README that still called it GitHub, and not GitLab. Just quickly fixed them.

Thanks!